### PR TITLE
Hungarian translation and small fixes

### DIFF
--- a/ChangeWorkorderState.sopm
+++ b/ChangeWorkorderState.sopm
@@ -2,21 +2,25 @@
 <otrs_package version="1.0">
     <!-- GENERATED WITH OTRS::OPM::Maker::Command::sopm (1.33) -->
     <Name>ChangeWorkorderState</Name>
-    <Version>5.0.3</Version>
+    <Version>5.0.4</Version>
     <Framework>5.0.x</Framework>
     <PackageRequired Version="5.0.1">ITSMChangeManagement</PackageRequired>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de</URL>
     <Description Lang="de">Status der Workorder auf Basis ihres geplanten Endes und Status des Changes auf Basis der 'letzten' Workorder ändern.</Description>
-    <Description Lang="en">change state of workorders based on their planned end time and change state of the change based on the 'last' workorder.</Description>
+    <Description Lang="en">Change state of workorders based on their planned end time and change state of the change based on the 'last' workorder.</Description>
+    <Description Lang="hu">A munkamegrendelések állapotának megváltoztatása a tervezett befejezési idejük alapján, és a változás állapotának megváltoztatása az „utolsó” munkamegrendelés alapján.</Description>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
     <Filelist>
         <File Permission="644" Location="Custom/Kernel/System/ITSMChange/ChangeWorkorderState.pm" />
         <File Permission="644" Location="Custom/Kernel/System/ITSMChange/Event/TriggerChangeStateUpdate.pm" />
         <File Permission="644" Location="Kernel/Config/Files/ChangeWorkorderState.xml" />
+        <File Permission="644" Location="Kernel/Language/de_ChangeWorkorderState.pm" />
+        <File Permission="644" Location="Kernel/Language/hu_ChangeWorkorderState.pm" />
         <File Permission="644" Location="Kernel/System/Console/Command/Maint/ITSMChange/ChangeWorkorderState.pm" />
         <File Permission="644" Location="doc/ChangeWorkorderState.json" />
         <File Permission="644" Location="doc/en/ChangeWorkorderState.pod" />
+        <File Permission="644" Location="doc/hu/ChangeWorkorderState.pod" />
         <File Permission="644" Location="var/cron/change_workorder_state.dist" />
     </Filelist>
 </otrs_package>

--- a/Kernel/Config/Files/ChangeWorkorderState.xml
+++ b/Kernel/Config/Files/ChangeWorkorderState.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_config version="1.0" init="Config">
     <ConfigItem Name="ChangeWorkorderState::Debug" Required="0" Valid="1">
-        <Description Translatable="1">En-/Disables debugging mode for ChangeWorkorderState</Description>
+        <Description Translatable="1">En-/Disables debugging mode for ChangeWorkorderState.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -12,7 +12,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::ChangeNewStateDelayed" Required="0" Valid="0">
-        <Description Translatable="1">New state for Change when "any" Workorder is delayed.</Description>
+        <Description Translatable="1">New state for change when "any" workorder is delayed.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -20,7 +20,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::ChangeNewStateOverdue" Required="0" Valid="0">
-        <Description Translatable="1">New state for Change when "last" Workorder is delayed.</Description>
+        <Description Translatable="1">New state for change when "last" workorder is delayed.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -28,7 +28,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::WorkorderNewStateDelayed" Required="0" Valid="0">
-        <Description Translatable="1">New state for Workorder when it is delayed.</Description>
+        <Description Translatable="1">New state for workorder when it is delayed.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -36,7 +36,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::WorkorderNewStateOverdue" Required="0" Valid="0">
-        <Description Translatable="1">New state for Workorder when it is delayed.</Description>
+        <Description Translatable="1">New state for workorder when it is overdued.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -58,7 +58,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::WorkorderTypes" Required="0" Valid="0">
-        <Description Translatable="1">Workorders of those types are considered for state changes.</Description>
+        <Description Translatable="1">Workorders with those types are considered for state changes.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -78,7 +78,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::TimeUnit" Required="1" Valid="1">
-        <Description Translatable="1">Define which unit is used for time accounting</Description>
+        <Description Translatable="1">Defines which unit is used for time accounting.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -95,7 +95,7 @@
         <SubGroup>Daemon::SchedulerCronTaskManager::Task</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="TaskName">Change Workorder States</Item>
+                <Item Key="TaskName" Translatable="1">Change Workorder States</Item>
                 <Item Key="Schedule">*/10 * * * *</Item> <!-- default: every 10 minutes -->
                 <Item Key="Module">Kernel::System::Console::Command::Maint::ITSMChange::ChangeWorkorderState</Item>
                 <Item Key="Function">Execute</Item>
@@ -108,7 +108,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ITSMWorkOrder::EventModule###05-TriggerChangeStateUpdate" Required="0" Valid="0">
-        <Description Translatable="1">ITSM event module updates the change state based on the workorder state.</Description>
+        <Description Translatable="1">ITSM event module that updates the change state based on the workorder state.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>UpdateChangeState</SubGroup>
         <Setting>
@@ -120,7 +120,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::TriggerState" Required="0" Valid="0">
-        <Description Translatable="1">Workorders that state is changed to this state trigger a change of the change state.</Description>
+        <Description Translatable="1">Workorders that state is changed to this state and trigger a change of the change state.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>UpdateChangeState</SubGroup>
         <Setting>
@@ -128,7 +128,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ChangeWorkorderState::ChangeNewState" Required="0" Valid="0">
-        <Description Translatable="1">New state for Change when Workorder state update triggers an change state update.</Description>
+        <Description Translatable="1">New state for change when workorder state update triggers a change state update.</Description>
         <Group>ChangeWorkorderState</Group>
         <SubGroup>UpdateChangeState</SubGroup>
         <Setting>

--- a/Kernel/Language/de_ChangeWorkorderState.pm
+++ b/Kernel/Language/de_ChangeWorkorderState.pm
@@ -1,0 +1,50 @@
+# --
+# Kernel/Language/de_ChangeWorkorderState.pm - the German translation for ChangeWorkorderState
+# Copyright (C) 2014-2016 Perl-Services, http://www.perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::de_ChangeWorkorderState;
+
+use strict;
+use warnings;
+
+use utf8;
+
+our $VERSION = 0.01;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    # Kernel/Config/Files/ChangeWorkorderState.xml
+    $Lang->{'En-/Disables debugging mode for ChangeWorkorderState.'} = '';
+    $Lang->{'New state for change when "any" workorder is delayed.'} = '';
+    $Lang->{'New state for change when "last" workorder is delayed.'} = '';
+    $Lang->{'New state for workorder when it is delayed.'} = '';
+    $Lang->{'New state for workorder when it is overdued.'} = '';
+    $Lang->{'Workorders with those states are considered for state changes.'} = '';
+    $Lang->{'Workorders with those types are considered for state changes.'} = '';
+    $Lang->{'Ratio of remaining (planned) effort and remaining time that is used to check whether a workorder state should be changed.'} = '';
+    $Lang->{'Defines which unit is used for time accounting.'} = '';
+    $Lang->{'Change state for delayed workorders.'} = '';
+    $Lang->{'Change Workorder States'} = '';
+    $Lang->{'ITSM event module that updates the change state based on the workorder state.'} = '';
+    $Lang->{'Workorders that state is changed to this state and trigger a change of the change state.'} = '';
+    $Lang->{'New state for change when workorder state update triggers a change state update.'} = '';
+    $Lang->{'Minute'} = 'Minute';
+    $Lang->{'Hour'} = 'Stunde';
+    $Lang->{'Day'} = 'Tag';
+    $Lang->{'No'} = 'Nein';
+    $Lang->{'Yes'} = 'Ja';
+
+    return 1;
+}
+
+1;

--- a/Kernel/Language/hu_ChangeWorkorderState.pm
+++ b/Kernel/Language/hu_ChangeWorkorderState.pm
@@ -1,0 +1,61 @@
+# --
+# Kernel/Language/hu_ChangeWorkorderState.pm - the Hungarian translation for ChangeWorkorderState
+# Copyright (C) 2014-2016 Perl-Services, http://www.perl-services.de
+# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_ChangeWorkorderState;
+
+use strict;
+use warnings;
+
+use utf8;
+
+our $VERSION = 0.01;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    # Kernel/Config/Files/ChangeWorkorderState.xml
+    $Lang->{'En-/Disables debugging mode for ChangeWorkorderState.'} =
+        'Engedélyezi vagy letiltja a ChangeWorkorderState hibakereső módját.';
+    $Lang->{'New state for change when "any" workorder is delayed.'} =
+        'A változás új állapota, amikor „bármely” munkamegrendelés késik.';
+    $Lang->{'New state for change when "last" workorder is delayed.'} =
+        'A változás új állapota, amikor az „utolsó” munkamegrendelés késik.';
+    $Lang->{'New state for workorder when it is delayed.'} = 'A munkamegrendelés új állapota, amikor késik.';
+    $Lang->{'New state for workorder when it is overdued.'} = 'A munkamegrendelés új állapota, amikor lejárt.';
+    $Lang->{'Workorders with those states are considered for state changes.'} =
+        'Az ilyen állapotú munkamegrendelések lesznek figyelembe véve az állapotváltozásoknál.';
+    $Lang->{'Workorders with those types are considered for state changes.'} =
+        'Az ilyen típusú munkamegrendelések lesznek figyelembe véve az állapotváltozásoknál.';
+    $Lang->{'Ratio of remaining (planned) effort and remaining time that is used to check whether a workorder state should be changed.'} =
+        'A hátralévő (tervezett) ráfordítás és a hátralévő idő aránya, amely annak ellenőrzéséhez használható, hogy egy munkamegrendelés állapotát meg kell-e változtatni.';
+    $Lang->{'Defines which unit is used for time accounting.'} =
+        'Meghatározza, hogy milyen egység legyen használva az időelszámolásnál.';
+    $Lang->{'Change state for delayed workorders.'} = 'Változásállapot a késésben lévő munkamegrendeléseknél.';
+    $Lang->{'Change Workorder States'} = 'Munkamegrendelés-állapotok megváltoztatása';
+    $Lang->{'ITSM event module that updates the change state based on the workorder state.'} =
+        'ITSM eseménymodul, amely frissíti a változás állapotát a munkamegrendelés állapota alapján.';
+    $Lang->{'Workorders that state is changed to this state and trigger a change of the change state.'} =
+        'Munkamegrendelések, amelyek állapota erre az állapotra lett megváltoztatva, és aktiválják a változásállapot megváltoztatását.';
+    $Lang->{'New state for change when workorder state update triggers a change state update.'} =
+        'A változás új állapota, amikor a munkamegrendelés állapotfrissítése aktivál egy változásállapot frissítést.';
+    $Lang->{'Minute'} = 'Perc';
+    $Lang->{'Hour'} = 'Óra';
+    $Lang->{'Day'} = 'Nap';
+    $Lang->{'No'} = 'Nem';
+    $Lang->{'Yes'} = 'Igen';
+
+    return 1;
+}
+
+1;

--- a/doc/ChangeWorkorderState.json
+++ b/doc/ChangeWorkorderState.json
@@ -1,6 +1,6 @@
 {
     "name": "ChangeWorkorderState",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "framework": [
         "5.0.x"
     ],
@@ -10,8 +10,9 @@
     },
     "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007",
     "description" : {
-        "en": "change state of workorders based on their planned end time and change state of the change based on the 'last' workorder.",
-        "de": "Status der Workorder auf Basis ihres geplanten Endes und Status des Changes auf Basis der 'letzten' Workorder ändern."
+        "en": "Change state of workorders based on their planned end time and change state of the change based on the 'last' workorder.",
+        "de": "Status der Workorder auf Basis ihres geplanten Endes und Status des Changes auf Basis der 'letzten' Workorder ändern.",
+        "hu": "A munkamegrendelések állapotának megváltoztatása a tervezett befejezési idejük alapján, és a változás állapotának megváltoztatása az „utolsó” munkamegrendelés alapján."
     },
     "requires" : {
         "package" : {

--- a/doc/en/ChangeWorkorderState.pod
+++ b/doc/en/ChangeWorkorderState.pod
@@ -1,6 +1,9 @@
+=encoding utf-8
+
 =head1 NAME
 
-ChangeWorkorderState
+ChangeWorkorderState - Change state of workorders based on their planned end time and change
+state of the change based on the 'last' workorder.
 
 =head1 DESCRIPTION
 
@@ -8,28 +11,28 @@ This addon adds a cronjob that checks if the planned end time of a workorder has
 so, the workorder state is set to I<delayed>. If the delayed workorder is the "last" workorder
 of a change, the change state is set to I<delayed>.
 
-You can also set an "available time / effor ratio". If you have set a planned effort of 5 hours
+You can also set an "available time / effort ratio". If you have set a planned effort of 5 hours
 and there are already 3 hours accounted, there are 2 hours left. If the planned end time of the
-workorder is in 2.5 hours and you configured a ration of 60%, the workorder state will be set
+workorder is in 2.5 hours and you configured a ratio of 60%, the workorder state will be set
 to I<delayed>.
 
-After installation you have to activate the cronjob that checks the workorders...
+After installation you have to activate the cronjob that checks the workorders.
 
 =head1 ACKNOWLEDGEMENT
 
-The development of this addon was sponsored by
-L<http://www.hefter-maschinenbau.de>.
+The development of this addon was sponsored by L<http://www.hefter-maschinenbau.de>.
 
-=head1 SOURCECODE AND BUGTRACKER
+Hungarian translation by Balázs Úr, L<http://www.otrs-megoldasok.hu>.
+
+=head1 SOURCE CODE AND BUGTRACKER
 
 The code repository and a bugtracker is available at L<http://github.com/reneeb/otrs-ChangeWorkorderState>.
-Please report any bugs and feature requests on github or via mail.
+Please report any bugs and feature requests on GitHub or via mail.
 
 =head1 AUTHOR AND LICENSE
 
-This package was written by Renee Baecker E<lt>otrs@perl-services.deE<gt>.
+This package was written by Renée Bäcker E<lt>otrs@perl-services.deE<gt>.
 
 The package is licensed unter AGPL. If you
 did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
-
 

--- a/doc/hu/ChangeWorkorderState.pod
+++ b/doc/hu/ChangeWorkorderState.pod
@@ -1,0 +1,42 @@
+=encoding utf-8
+
+=head1 NÉV
+
+ChangeWorkorderState - A munkamegrendelések állapotának megváltoztatása a tervezett befejezési
+idejük alapján, és a változás állapotának megváltoztatása az „utolsó” munkamegrendelés alapján.
+
+=head1 LEÍRÁS
+
+Ez a kiegészítő egy cron-feladatot ad hozzá, amely azt ellenőrzi, hogy egy munkamegrendelés
+tervezett befejezési ideje elmúlt-e. Ha igen, akkor a munkamegrendelés I<késés> állapotra lesz
+állítva. Ha a késedelmes munkamegrendelés a változás „utolsó” munkamegrendelése, akkor a változás
+is I<késés> állapotra lesz állítva.
+
+Beállíthat egy „elérhető idő / ráfordítás arányt” is. Ha 5 óra tervezett ráfordítás van beállítva,
+és már 3 óra el lett számolva, akkor 2 óra van hátra. Ha a munkamegrendelés a tervezett befejezési
+idejét 2,5 óra múlva érné el, és 60%-os arányt állított be, akkor a munkamegrendelés I<késés>
+állapota lesz állítva.
+
+Telepítés után be kell kapcsolnia azt a cron-feladatot, amely ellenőrzi a munkamegrendeléseket.
+
+=head1 KÖSZÖNETNYILVÁNÍTÁS
+
+Ennek a kiegészítőnek a fejlesztését a L<http://www.hefter-maschinenbau.de> támogatta.
+
+=head1 FORRÁSKÓD ÉS HIBAKÖVETŐ
+
+A kódtároló és a hibakövető a L<http://github.com/reneeb/otrs-ChangeWorkorderState> címen érhető
+el. Kérjük, hogy a hibákat és a funkciókéréseket a GitHub-on vagy e-mailben jelentse.
+
+=head1 SZERZŐ ÉS LICENC
+
+A csomag szerzője: Renée Bäcker E<lt>otrs@perl-services.deE<gt>.
+
+A csomag AGPL alatt licencelt. Ha nem kapta meg ezt a fájlt, akkor nézze meg a
+L<http://www.gnu.org/licenses/agpl.txt> oldalon.
+
+=head1 MAGYAR FORDÍTÁS
+
+A magyar fordítást az OTRS-megoldások csapata készítette.
+Copyright (C) 2016 Úr Balázs, L<http://otrs-megoldasok.hu>
+


### PR DESCRIPTION
Hi @reneeb 
Here is the Hungarian translation for ChangeWorkorderState module. This PR contains some small fixes, as usual.
I found a meaningless sentence: "Workorders that state is changed to this state trigger a change of the change state." I tried to correct it by adding an "and". If this would mean something else, then please change it.
I also added the incomplete German language file. Can you finish it?
